### PR TITLE
report includes details

### DIFF
--- a/src/main/java/testCase/StepSelenium.java
+++ b/src/main/java/testCase/StepSelenium.java
@@ -11,6 +11,7 @@ public class StepSelenium {
     private String description;
     private String stepDescription;
     private String name;
+    private String takeScreenShot;
 
     public StepSelenium(String number, String keyword, String locatorType, String locatorValue, String value, String description, String stepDescription, String name) {
         this.number = number;
@@ -21,6 +22,7 @@ public class StepSelenium {
         this.description = description;
         this.stepDescription = stepDescription;
         this.name = name;
+        this.takeScreenShot = number;
     }
 
     public void setNumber(String number) {
@@ -87,7 +89,15 @@ public class StepSelenium {
     	this.name = name;
     }
     
-    @Override
+    public String getTakeScreenShot() {
+		return takeScreenShot;
+	}
+
+	public void setTakeScreenShot(String takeScreenShot) {
+		this.takeScreenShot = takeScreenShot;
+	}
+
+	@Override
 	public String toString() {
 		return "StepSelenium [number=" + number + ", keyword=" + keyword + ", locatorType=" + locatorType
 				+ ", locatorValue=" + locatorValue + ", value=" + value + ", description=" + description


### PR DESCRIPTION
report includes steps details and screenshot if the template has a 'y' in the 4th column,
report name is generated as target/report_datetime.html
report is opened automatically at the end of the execution
![image](https://user-images.githubusercontent.com/10228591/112231668-c058da00-8bfc-11eb-925a-dd9aa72a5537.png)

